### PR TITLE
fix README typo in `go run` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 POC using dagger.io
 
-`go run dagger.io`
+`go run dagger.go`


### PR DESCRIPTION
👋 Hi @maxknee ! Thanks for the cool demo; this PR fixes a subtle typo in the `README`.